### PR TITLE
remove rar dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ ENV APTLIST="wget python"
 
 RUN apt-get update && \
 apt-get install $APTLIST -qy && \
-curl -o /tmp/rar.tar.gz http://www.rarlab.com/rar/rarlinux-x64-5.3.b5.tar.gz && \
-tar xvf /tmp/rar.tar.gz  -C /tmp && \
-cp -v /tmp/rar/*rar /usr/bin/ && \
 apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
 
 #Adding Custom files


### PR DESCRIPTION
nzbget already has unrar in it's /app directory. I'm not sure that it's necessary to also download rar especially since we don't change nzbget.conf to point to our downloaded rar.