### PR TITLE
remove wget dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM linuxserver/baseimage
 MAINTAINER Stian Larsen <lonixx@gmail.com>
 
-ENV APTLIST="wget python"
+ENV APTLIST="python"
 
 RUN apt-get update && \
 apt-get install $APTLIST -qy && \

--- a/init/40_install_or_update.sh
+++ b/init/40_install_or_update.sh
@@ -25,7 +25,7 @@ fi
 
 if [ "$LOCAL_VERSION" != "$REMOTE_VERSION" ]; then
 		echo "Not up-to-date\Installed"
-		wget -O /tmp/nzbget.run "$DOWNLOAD"
+		curl -o /tmp/nzbget.run -L "$DOWNLOAD"
 		/sbin/setuser abc sh /tmp/nzbget.run --destdir /app
 		if [ -x /app/nzbget ]; then echo "Install successfull"; fi
 fi


### PR DESCRIPTION
In [14d95183](https://github.com/linuxserver/docker-nzbget/commit/14d95183be4bbf50aa8cbf355a52c01e7822cc10), we switched from cURL to wget. I'm guessing because the redirect was failing with cURL. Following the redirect with `-L <URL>' works just fine for me and gets rid of the extraneous wget dependency. :thumbsup: