### PR TITLE
allow nzbget to start in foreground

### DIFF
--- a/init/50_check_config.sh
+++ b/init/50_check_config.sh
@@ -19,4 +19,3 @@ fi
 echo "Checking som config options"
 sed -i -e "s#\(WebDir=\).*#\1$\{AppDir\}/webui#g" /config/nzbget.conf
 sed -i -e "s#\(ConfigTemplate=\).*#\1$\{AppDir\}/webui/nzbget.conf.template#g" /config/nzbget.conf
-sed -i -e "s#\(LogFile=\).*#\1$\{MainDir\}/nzbget.log#g" /config/nzbget.conf

--- a/services/nzbget/run
+++ b/services/nzbget/run
@@ -1,6 +1,4 @@
 #!/bin/bash
 umask 000
 
-/sbin/setuser abc /app/nzbget -D -c /config/nzbget.conf
-sleep 2s
-exec /sbin/setuser abc tail -F /downloads/nzbget.log --pid="$(cat /downloads/nzbget.lock)"
+/sbin/setuser abc /app/nzbget -s -c /config/nzbget.conf -o OutputMode=log


### PR DESCRIPTION
This should help with #3. 

In order to run NZBGet in the foreground appropriately, you have to pass the `OutputMode` option. I'm guessing it defaults to `curses` which was what I experienced.

```bash
nzbget -s -c /path/to/config.conf -o OutputMode=logs
```

This removes the reliance on the hardcoded location of the lock and log files.