### PR TITLE
remove unnecessary config manipulation

### DIFF
--- a/init/50_check_config.sh
+++ b/init/50_check_config.sh
@@ -6,12 +6,9 @@ if [ ! -f /config/nzbget.conf ]; then
   cp -v /app/nzbget.conf /config/nzbget.conf
   echo "Changeing some defaults to match our container"
   sed -i -e "s#\(MainDir=\).*#\1/downloads#g" /config/nzbget.conf
-  sed -i -e "s#\(UMask=\).*#\1000#g" /config/nzbget.conf
   sed -i -e "s#\(ScriptDir=\).*#\1$\{MainDir\}/scripts#g" /config/nzbget.conf
-  sed -i -e "s#\(ControlIP=\).*#\10.0.0.0#g" /config/nzbget.conf
   chown abc:abc /config/nzbget.conf
   chmod u+rw /config/nzbget.conf
-  mkdir -p /downloads/dst
   chown -R abc:abc /downloads
 fi
 


### PR DESCRIPTION
In the case of `/downloads/dst`, that directory isn't used on Linux (it's `/downloads/completed`).

For the two configuration parameters, those are already the default so removing them helps cut down the complexity just a little bit.

config file defaults reference:
https://github.com/nzbget/nzbget/blob/develop/nzbget.conf
https://github.com/nzbget/nzbget/blob/develop/linux/build-nzbget#L341