### PR TITLE
symlink unrar for PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV APTLIST="python"
 
 RUN apt-get update && \
 apt-get install $APTLIST -qy && \
+ln -fs /app/unrar /usr/bin/unrar && \
 apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
 
 #Adding Custom files


### PR DESCRIPTION
this fixes a pathing issue #9 brought up. nzbget does not have /app in its pathing and by default cant find unrar.