### PR TITLE
Fix the parameters section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,7 @@ Add one of the tags,  if required,  to the linuxserver/nzbget line of the run/cr
 
 ## Parameters
 
-`The parameters are split into two halves, separated by a colon, the left hand side representing the host and the right the container side. 
-For example with a port -p external:internal - what this shows is the port mapping from internal to external of the container.
-So -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080
-http://192.168.x.x:8080 would show you what's running INSIDE the container on port 80.`
-
+The parameters are split into two halves, separated by a colon, the left hand side representing the host and the right the container side. For example, with a port -p external:internal - what this shows is the port mapping from internal to external of the container. So -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080. `http://192.168.x.x:8080` would show you what's running INSIDE the container on port 80.
 
 * `-p 6789` - NZBGet WebUI Port
 * `-v /config` - NZBGet App data
@@ -55,7 +51,6 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-e PGID` for for GroupID - see below for explanation
 * `-e PUID` for for UserID - see below for explanation
 * `-e TZ` for timezone EG. Europe/London
-
 
 ### User / Group Identifiers
 


### PR DESCRIPTION
The documentation section for Parameters had some erroneous ` characters.