### PR TITLE
rebasing to alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Buildstage
-FROM lsiobase/alpine:3.8 as buildstage
+FROM lsiobase/alpine:3.9 as buildstage
 
 # set NZBGET version
 ARG NZBGET_RELEASE
@@ -24,6 +24,7 @@ RUN \
  git clone https://github.com/nzbget/nzbget.git nzbget && \
  cd nzbget/ && \
  git checkout ${NZBGET_RELEASE} && \
+ git cherry-pick -n fa57474d && \
  ./configure \
 	bindir='${exec_prefix}' && \
  make && \
@@ -52,7 +53,7 @@ RUN \
 	"https://curl.haxx.se/ca/cacert.pem"
 
 # Runtime Stage
-FROM lsiobase/alpine:3.8
+FROM lsiobase/alpine:3.9
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,5 +1,5 @@
 # Buildstage
-FROM lsiobase/alpine.arm64:3.8 as buildstage
+FROM lsiobase/alpine.arm64:3.9 as buildstage
 
 # set NZBGET version
 ARG NZBGET_RELEASE
@@ -24,6 +24,7 @@ RUN \
  git clone https://github.com/nzbget/nzbget.git nzbget && \
  cd nzbget/ && \
  git checkout ${NZBGET_RELEASE} && \
+ git cherry-pick -n fa57474d && \
  ./configure \
 	bindir='${exec_prefix}' && \
  make && \
@@ -52,7 +53,7 @@ RUN \
 	"https://curl.haxx.se/ca/cacert.pem"
 
 # Runtime Stage
-FROM lsiobase/alpine.arm64:3.8
+FROM lsiobase/alpine.arm64:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-aarch64-static /usr/bin

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,5 +1,5 @@
 # Buildstage
-FROM lsiobase/alpine.armhf:3.8 as buildstage
+FROM lsiobase/alpine.armhf:3.9 as buildstage
 
 # set NZBGET version
 ARG NZBGET_RELEASE
@@ -24,6 +24,7 @@ RUN \
  git clone https://github.com/nzbget/nzbget.git nzbget && \
  cd nzbget/ && \
  git checkout ${NZBGET_RELEASE} && \
+ git cherry-pick -n fa57474d && \
  ./configure \
 	bindir='${exec_prefix}' && \
  make && \
@@ -52,7 +53,7 @@ RUN \
 	"https://curl.haxx.se/ca/cacert.pem"
 
 # Runtime Stage
-FROM lsiobase/alpine.armhf:3.8
+FROM lsiobase/alpine.armhf:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-arm-static /usr/bin

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "25.02.19:", desc: "Rebasing to alpine 3.9." }
   - { date: "20.01.19:", desc: "Add pipeline logic and multi arch, build from source." }
   - { date: "21.08.18:", desc: "Rebase to alpine 3.8." }
   - { date: "20.02.18:", desc: "Add note about supplemental mount point for intermediate unpacking." }


### PR DESCRIPTION
Slight stopgap in this one , I cherry pick a fix for compiling against openssl v1.1, as we do not know when v21 will be released we should move forward with Alpine 3.9 and make this tiny modifcation to their codebase. 

https://lsio-ci.ams3.digitaloceanspaces.com/lsiodev/nzbget/v20.0-pkg-b0bb2447-dev-2831fb731b0e5dc17c60ad6f3d4d4a88f4c3d55a/index.html

If you have concern about merging please pull the image above locally and test.
