### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Buildstage
-FROM lsiobase/alpine:3.9 as buildstage
+FROM lsiobase/alpine:3.10 as buildstage
 
 # set NZBGET version
 ARG NZBGET_RELEASE
@@ -54,7 +54,7 @@ RUN \
 	"https://curl.haxx.se/ca/cacert.pem"
 
 # Runtime Stage
-FROM lsiobase/alpine:3.9
+FROM lsiobase/alpine:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,5 +1,5 @@
 # Buildstage
-FROM lsiobase/alpine:arm64v8-3.9 as buildstage
+FROM lsiobase/alpine:arm64v8-3.10 as buildstage
 
 # set NZBGET version
 ARG NZBGET_RELEASE
@@ -54,7 +54,7 @@ RUN \
 	"https://curl.haxx.se/ca/cacert.pem"
 
 # Runtime Stage
-FROM lsiobase/alpine:arm64v8-3.9
+FROM lsiobase/alpine:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,5 +1,5 @@
 # Buildstage
-FROM lsiobase/alpine:arm32v7-3.9 as buildstage
+FROM lsiobase/alpine:arm32v7-3.10 as buildstage
 
 # set NZBGET version
 ARG NZBGET_RELEASE
@@ -54,7 +54,7 @@ RUN \
 	"https://curl.haxx.se/ca/cacert.pem"
 
 # Runtime Stage
-FROM lsiobase/alpine:arm32v7-3.9
+FROM lsiobase/alpine:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "13.06.19:", desc: "Add apprise, chardet & pynzbget packages." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "22.02.19:", desc: "Rebasing to alpine 3.9." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.