### PR TITLE
update readme with python 3 information

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ You can add an additional mount point for intermediate unpacking folder with:-
 
 for example, and changing the setting for InterDir in the PATHS tab of settings to `/intermediate`
 
+## Python 3 transition
+
+We provide Python and related packages in this image for extension support. While extensions transition to Python 3 we will install both Python 2 and Python 3 in the standard container. If you want to force your extensions to use Python 3 you should modify:
+
+`Settings => Extension Scripts => ShellOverride = .py=/usr/bin/python3`
+
 
 
 ## Support Info

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -68,6 +68,12 @@ app_setup_block: |
 
   for example, and changing the setting for InterDir in the PATHS tab of settings to `/intermediate`
 
+  ## Python 3 transition
+  
+  We provide Python and related packages in this image for extension support. While extensions transition to Python 3 we will install both Python 2 and Python 3 in the standard container. If you want to force your extensions to use Python 3 you should modify:
+  
+  `Settings => Extension Scripts => ShellOverride = .py=/usr/bin/python3`
+
 # changelog
 changelogs:
   - { date: "01.01.20:", desc: "Add python3 alongside python2 during transition." }


### PR DESCRIPTION
ref: https://github.com/linuxserver/docker-nzbget/issues/91

There are multiple ways to do this but I think the universal override is the best for now as most people only use 1 or two extensions and they just want to force it to work. 