### PR TITLE
symlink python to python3 testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ RUN \
 	apprise \
 	chardet \
 	pynzbget &&\
+ ln -s /usr/bin/python3 /usr/bin/python && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -87,6 +87,7 @@ RUN \
 	apprise \
 	chardet \
 	pynzbget &&\
+ ln -s /usr/bin/python3 /usr/bin/python && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -87,6 +87,7 @@ RUN \
 	apprise \
 	chardet \
 	pynzbget &&\
+ ln -s /usr/bin/python3 /usr/bin/python && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **08.06.20:** - Symlink python3 bin to python.
 * **01.06.20:** - Rebasing to alpine 3.12. Removing python2.
 * **01.01.20:** - Add python3 alongside python2 during transition.
 * **19.12.19:** - Rebasing to alpine 3.11.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "08.06.20:", desc: "Symlink python3 bin to python." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12. Removing python2." }
   - { date: "01.01.20:", desc: "Add python3 alongside python2 during transition." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }


### PR DESCRIPTION
I don't see many downsides to this, if a script supports python3 it will just work and if not the user is on their own to install python2 as a customization. 
If python2 is installed it overrides this symlink fine. 