### PR TITLE
Fix ignored umask env var by removing overwrite (testing)

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "24.08.20:", desc: "Fix ignored umask environment variable." }
   - { date: "08.06.20:", desc: "Symlink python3 bin to python." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12. Removing python2." }
   - { date: "01.01.20:", desc: "Add python3 alongside python2 during transition." }

--- a/root/etc/services.d/nzbget/run
+++ b/root/etc/services.d/nzbget/run
@@ -1,7 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-umask 022
-
 exec \
 	s6-setuidgid abc /app/nzbget/nzbget -s -c /config/nzbget.conf \
 	-o OutputMode=log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
I bumped into an issue that the new UMASK environment variable did not seem to work for the NZBGet service. The UMask was always 022.

4 years ago (so long before the UMASK env var) commit 64dc5f4cf9edb516dd3fb95b6f143c338291e9d6 added a line in the nzbget service run file to set the UMask to 022. I could not find a reason for this change. #26 doesn't give more information.

This static UMask got applied after the env var UMask got applied.

This PR removes the static UMask. This results in:
- UMASK env var is filled: The configured UMask is applied.
- UMASK env var is empty: The default UMask of the default `abc` user in the container is used. This is 022.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR fixes a bug for users that have configured a UMask using the environment variable. Users that have not configured a special UMask get the default 022, just like before. That should make the change safe for everyone.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I started a container using the following docker-compose.yml service snippet:

```yaml
  nzbget:
    container_name: nzbget
    build: ./nzbget-code/docker-nzbget
    restart: unless-stopped
    networks:
      - frontend
    volumes:
      - /mnt/Data1/media/NZBGet:/downloads
      - ./nzbget/config:/config
      - ./shared:/shared
    environment:
      - UMASK=002
      - PUID=${PUID_NZBGET}
      - PGID
      - TZ
```

Next I started a download and enter a shell in the container. There I ran the commands described in the Discord conversation below to check the UMask of the currently running nzbget and unrar processes.
```
root@f19036f8a0a2:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0    196     4 ?        Ss   23:05   0:00 s6-svscan -t0 /var/run/s6/services
root          35  0.0  0.0    196     4 ?        S    23:05   0:00 s6-supervise s6-fdholderd
root         254  0.0  0.0    196     4 ?        S    23:05   0:00 s6-supervise nzbget
abc          258 39.9  1.0  49152 41716 ?        Ssl  23:05   3:58 /app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log
root         282  0.0  0.0   2424  1148 pts/0    Ss   23:05   0:00 /bin/bash
abc        16577 23.2  0.0   4396  2100 ?        Ds   23:11   0:57 /app/nzbget/unrar x -y -p- -o+ *.rar /downloads/Downloads/Some.Random.Name/_unpack/
root       17132  0.0  0.0   1616   524 pts/0    R+   23:15   0:00 ps aux
root@f19036f8a0a2:/# grep '^Umask:' "/proc/16577/status"
Umask:  0002
root@f19036f8a0a2:/# grep '^Umask:' "/proc/258/status"
Umask:  0002
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
The following is the short Discord discussion I had about this subject.

JMolnar
Hi, I'm trying to configure the umask for my nzbget container as described here: https://github.com/linuxserver/docker-nzbget#umask-for-running-applications
But it seems like this setting doesn't work.

I test this by connecting to the container using `sudo docker exec -it nzbget /bin/bash` and then running `grep '^Umask:' "/proc/12345/status"` where 12345 is the PID of the /app/nzbget/nzbget process. (I get the PID by running `ps aux`)
The response I get in the nzbget container is `Umask:  0022`.
I also tried running it in the rutorrent container, where I get `Umask:  0002` as expected.

My docker-compose service snippet is:
```yaml
  nzbget:
    container_name: nzbget
    image: linuxserver/nzbget
    restart: unless-stopped
    networks:
      - frontend
    volumes:
      - /mnt/Data1/media/NZBGet:/downloads
      - ./nzbget/config:/config
      - ./shared:/shared
    environment:
      - UMASK=002
      - PUID=${PUID_NZBGET}
      - PGID
      - TZ
```

j0nnymoe
@JorisMolnar you can set the UMASK via the nzbget settings I believe aswell

JMolnar
I noticed the following file always sets the umask to 022, but I don't know if there is some other system that should change it again: https://github.com/linuxserver/docker-nzbget/blob/master/root/etc/services.d/nzbget/run
Thanks @j0nnymoe, I'll take a look at that.
I found the setting in nzbget and can confirm that works :smile:
Thanks
The original setting was 1000, which nzbget says disables changing the umask, so it seems there still is an issue with the nzbget image. But at least there is a workaround :slight_smile:

JMolnar
Regarding that umask issue I mentioned 2 hours ago, it seems like we aren't completely there yet. 
NZBGet just extracted something and it had the wrong permissions.
I'd have to test further, but it's probably because the unrar process doesn't inherit the umask configured in nzbget settings. So unrar got 022 again :sweat_smile:
I'll take a look if I can spot the difference between the containers where the umask env variable works and doesn't work.

JMolnar
I think I fixed the issue. If my test succeeds I'll submit a pull request.
