### PR TITLE
Adding Lxml pip dependency for de-obfuscation scripts required by some indexers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ RUN \
  pip3 install --no-cache-dir \
 	apprise \
 	chardet \
+	lxml \
 	pynzbget \
 	rarfile && \
  ln -s /usr/bin/python3 /usr/bin/python && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -88,6 +88,7 @@ RUN \
  pip3 install --no-cache-dir \
 	apprise \
 	chardet \
+	lxml \
 	pynzbget \
 	rarfile && \
  ln -s /usr/bin/python3 /usr/bin/python && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -88,6 +88,7 @@ RUN \
  pip3 install --no-cache-dir \
 	apprise \
 	chardet \
+	lxml \
 	pynzbget \
 	rarfile && \
  ln -s /usr/bin/python3 /usr/bin/python && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding the lxml pip package for python scripts

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [ X] I have read the [contributing](https://github.com/linuxserver/docker-nzbget/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Adding the lxml pip package for python scripts

## Benefits of this PR and context:
Some indexers have begun obfuscating file names in NZBs, requiring new scripts to parse NZBs and decode filenames from the xml metadata.  These scripts have a dependency on lxml.
While currently limited in affected indexers, other nzb binary downloaders have patched to handle this.
This will likely become more pervasive with time.

## How Has This Been Tested?
custom docker build on personal Unraid 6.8.2
