### PR TITLE
Recursively chown /downloads

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -64,12 +64,11 @@ app_setup_block: |
 
   You can add an additional mount point for intermediate unpacking folder with:-
 
-  `-v </path/to/intermedia_unpacking_folder>:/intermediate`
-
-  for example, and changing the setting for InterDir in the PATHS tab of settings to `/intermediate`
+  `-v </path/to/intermedia_unpacking_folder>:/downloads/intermediate`
 
 # changelog
 changelogs:
+  - { date: "18.12.20:", desc: "Recursively chown /downloads." }
   - { date: "26.10.20:", desc: "Fix python dependencies." }
   - { date: "24.08.20:", desc: "Fix ignored umask environment variable." }
   - { date: "08.06.20:", desc: "Symlink python3 bin to python." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -12,7 +12,7 @@ mkdir -p /downloads
 	cp /app/nzbget/share/nzbget/nzbget.conf /config/nzbget.conf
 
 # permissions
-chown abc:abc \
+chown abc:abc -R \
 	/downloads
 chown abc:abc -R \
 	/app/nzbget \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-nzbget/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
So I was trying to mount an SSD-backed volume for the intermediate directory. I read the note about this in the README but happened upon two facts:
1. I have to manually configure NZBGet to use `/intermediate`
1. This directory is not chowned by cont-init.d, resulting in permissions issues, again requiring manual intervention

I could have submitted a PR to add conditional chown of `/intermediate` to cont-init.d, but I decided to fix both problems. By recursively chowning `/downloads`, I can mount my volume to `/downloads/intermediate` since docker supports nested volume mounts. This then fixes both issues.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Plug-and-play functionality for intermediates volume.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Did `docker-compose down -v` and altered my `docker-compose.yaml` to replace `image:` with:
```yaml
build: https://github.com/rfrowe/docker-nzbget#patch-1
```

Then did `docker-compose up`. No longer receive permissions error about `/downloads/intermediate` while downloading.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
N/A